### PR TITLE
Add author, playlist, and startup document types with fields for cont…

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from "next";
-            import localFont from "next/font/local";
-            import { Toaster } from 'react-hot-toast';
-            import "./globals.css";
+import localFont from "next/font/local";
+import { Toaster } from 'react-hot-toast';
+import "./globals.css";
+import "easymde/dist/easymde.min.css";
 
             const workSans = localFont({
                 src: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "react-dom": "^19.0.0",
         "react-hot-toast": "^2.5.2",
         "sanity": "^3.75.1",
+        "sanity-plugin-markdown": "^5.0.0",
         "styled-components": "^6.1.15",
         "tailwind-merge": "^3.0.1",
         "tailwindcss-animate": "^1.0.7",
@@ -6494,6 +6495,15 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/codemirror": {
+      "version": "5.60.15",
+      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.15.tgz",
+      "integrity": "sha512-dTOvwEQ+ouKJ/rE9LT1Ue2hmP6H1mZv5+CCnNWu2qtiOe2LQa9lCprEY20HxiDmV/Bxh+dXjywmy5aKvoGjULA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/tern": "*"
+      }
+    },
     "node_modules/@types/cookie": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
@@ -6549,6 +6559,13 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/marked": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.3.2.tgz",
+      "integrity": "sha512-a79Yc3TOk6dGdituy8hmTTJXjOkZ7zsFYV10L337ttq/rec8lRMDBpV7fL3uLx6TgbFCa5DU/h8FmIBQPSbU0w==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/minimist": {
       "version": "1.2.5",
@@ -6645,6 +6662,15 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/tern": {
+      "version": "0.23.9",
+      "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.9.tgz",
+      "integrity": "sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
       }
     },
     "node_modules/@types/trusted-types": {
@@ -8157,6 +8183,16 @@
         "@codemirror/view": "^6.0.0"
       }
     },
+    "node_modules/codemirror-spell-checker": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/codemirror-spell-checker/-/codemirror-spell-checker-1.1.2.tgz",
+      "integrity": "sha512-2Tl6n0v+GJRsC9K3MLCdLaMOmvWL0uukajNJseorZJsslaxZyZMgENocPU8R0DyoTAiKsyqiemSOZo7kjGV0LQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "typo-js": "*"
+      }
+    },
     "node_modules/color": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
@@ -9247,6 +9283,27 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "license": "MIT"
+    },
+    "node_modules/easymde": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/easymde/-/easymde-2.19.0.tgz",
+      "integrity": "sha512-4F1aNImqse+9xIjLh9ttfpOVenecjFPxUmKbl1tGp72Z+OyIqLZPE/SgNyy88c/xU0mOy0WC3+tfbZDQ5PDWhg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/codemirror": "^5.60.10",
+        "@types/marked": "^4.0.7",
+        "codemirror": "^5.65.15",
+        "codemirror-spell-checker": "1.1.2",
+        "marked": "^4.1.0"
+      }
+    },
+    "node_modules/easymde/node_modules/codemirror": {
+      "version": "5.65.18",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.18.tgz",
+      "integrity": "sha512-Gaz4gHnkbHMGgahNt3CA5HBk5lLQBqmD/pBgeB4kQU6OedZmqMBjlRF0LSrp2tJ4wlLNPm2FfaUd1pDy0mdlpA==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.102",
@@ -12869,6 +12926,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -15828,6 +15898,50 @@
         "styled-components": "^6.1"
       }
     },
+    "node_modules/sanity-plugin-markdown": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/sanity-plugin-markdown/-/sanity-plugin-markdown-5.0.0.tgz",
+      "integrity": "sha512-EzyJ6f/TcQevIZushOG5HKGIu9aUggktbH5th16EwTlHtGWjxO1aEuarMv362FmVaVYPh7YOHe9JuBkkGBE0KQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sanity/incompatible-plugin": "^1.0.4",
+        "@sanity/ui": "^2.8.9",
+        "react-simplemde-editor": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "easymde": "^2.18",
+        "react": "^18.3",
+        "sanity": "^3.23",
+        "styled-components": "^6.1"
+      }
+    },
+    "node_modules/sanity-plugin-markdown/node_modules/@sanity/incompatible-plugin": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@sanity/incompatible-plugin/-/incompatible-plugin-1.0.5.tgz",
+      "integrity": "sha512-9JGAacbElUPy9Chghd+sllIiM3jAcraZdD65bWYWUVKkghOsf1L/+jFLz1rcAuvrA9o2s7Y+T75BNcXuLwRcvw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.9 || ^17 || ^18 || ^19",
+        "react-dom": "^16.9 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/sanity-plugin-markdown/node_modules/react-simplemde-editor": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-simplemde-editor/-/react-simplemde-editor-5.2.0.tgz",
+      "integrity": "sha512-GkTg1MlQHVK2Rks++7sjuQr/GVS/xm6y+HchZ4GPBWrhcgLieh4CjK04GTKbsfYorSRYKa0n37rtNSJmOzEDkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/codemirror": "~5.60.5"
+      },
+      "peerDependencies": {
+        "easymde": ">= 2.0.0 < 3.0.0",
+        "react": ">=16.8.2",
+        "react-dom": ">=16.8.2"
+      }
+    },
     "node_modules/sanity/node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -17452,6 +17566,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/typo-js": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/typo-js/-/typo-js-1.2.5.tgz",
+      "integrity": "sha512-F45vFWdGX8xahIk/sOp79z2NJs8ETMYsmMChm9D5Hlx3+9j7VnCyQyvij5MOCrNY3NNe8noSyokRjQRfq+Bc7A==",
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react-dom": "^19.0.0",
     "react-hot-toast": "^2.5.2",
     "sanity": "^3.75.1",
+    "sanity-plugin-markdown": "^5.0.0",
     "styled-components": "^6.1.15",
     "tailwind-merge": "^3.0.1",
     "tailwindcss-animate": "^1.0.7",

--- a/sanity/schemaTypes/author.ts
+++ b/sanity/schemaTypes/author.ts
@@ -1,0 +1,40 @@
+import { defineField, defineType } from "sanity";
+import { UserIcon } from "lucide-react";
+
+export const author = defineType({
+    name: "author",
+    title: "Author",
+    type: "document",
+    icon: UserIcon,
+    fields: [
+        defineField({
+            name: "id",
+            type: "number",
+        }),
+        defineField({
+            name: "name",
+            type: "string",
+        }),
+        defineField({
+            name: "username",
+            type: "string",
+        }),
+        defineField({
+            name: "email",
+            type: "string",
+        }),
+        defineField({
+            name: "image",
+            type: "url",
+        }),
+        defineField({
+            name: "bio",
+            type: "text",
+        }),
+    ],
+    preview: {
+        select: {
+            title: "name",
+        },
+    },
+});

--- a/sanity/schemaTypes/playlist.ts
+++ b/sanity/schemaTypes/playlist.ts
@@ -1,0 +1,25 @@
+import { defineField, defineType } from "sanity";
+
+export const playlist = defineType({
+    name: "playlist",
+    title: "Playlists",
+    type: "document",
+    fields: [
+        defineField({
+            name: "title",
+            type: "string",
+        }),
+        defineField({
+            name: "slug",
+            type: "slug",
+            options: {
+                source: "title",
+            },
+        }),
+        defineField({
+            name: "select",
+            type: "array",
+            of: [{ type: "reference", to: [{ type: "startup" }] }],
+        }),
+    ],
+});

--- a/sanity/schemaTypes/startup.ts
+++ b/sanity/schemaTypes/startup.ts
@@ -1,0 +1,48 @@
+import { defineField, defineType } from "sanity";
+
+export const startup = defineType({
+    name: "startup",
+    title: "Startup",
+    type: "document",
+    fields: [
+        defineField({
+            name: "title",
+            type: "string",
+        }),
+        defineField({
+            name: "slug",
+            type: "slug",
+            options: {
+                source: "title",
+            },
+        }),
+        defineField({
+            name: "author",
+            type: "reference",
+            to: { type: "author" },
+        }),
+        defineField({
+            name: "views",
+            type: "number",
+        }),
+        defineField({
+            name: "description",
+            type: "text",
+        }),
+        defineField({
+            name: "category",
+            type: "string",
+            validation: (Rule) =>
+                Rule.min(1).max(20).required().error("Please enter a category"),
+        }),
+        defineField({
+            name: "image",
+            type: "url",
+            validation: (Rule) => Rule.required(),
+        }),
+        defineField({
+            name: "pitch",
+            type: "markdown",
+        }),
+    ],
+});


### PR DESCRIPTION
This pull request includes several changes to the codebase, focusing on adding new schema types for the Sanity content platform, updating dependencies, and including a new CSS import. The most important changes include adding new schema types for `author`, `playlist`, and `startup`, as well as updating the `package.json` to include a new plugin and adding a new CSS import.

### Schema Types Addition:
* [`sanity/schemaTypes/author.ts`](diffhunk://#diff-f021251702d739a935860e834d012e8136e09ec901d98d51f550de9678f50cacR1-R40): Added a new schema type for `author` with fields for id, name, username, email, image, and bio.
* [`sanity/schemaTypes/playlist.ts`](diffhunk://#diff-e8bacbaa4b7d6c0b2c28d31ecd17d23f599ba58855158513dac361c873139451R1-R25): Added a new schema type for `playlist` with fields for title, slug, and an array of references to `startup` documents.
* [`sanity/schemaTypes/startup.ts`](diffhunk://#diff-ac19d4eda840d255a667486542810e848fddd9e89c63a3799d5bd4fc7a79df91R1-R48): Added a new schema type for `startup` with fields for title, slug, author reference, views, description, category, image, and pitch.

### Dependency Updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R32): Added `sanity-plugin-markdown` version 5.0.0 to the dependencies.

### CSS Import:
* [`app/layout.tsx`](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bR5): Added import for `easymde/dist/easymde.min.css`.…ent management